### PR TITLE
fix: read params from form data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Sensemaker, OpenRouterModel, SummarizationType, VoteTally } from 'sense
 import type { Comment, Topic } from 'sensemaking-tools';
 import { parseCSVFile, parseTopicsString } from './utils/sensemake_openrouter_utils';
 import { parseJSONFile } from './utils/parseJSON';
+import { getFormDataString } from './utils/getFormDataString';
 
 /**
  * Sensemaker Backend API with Queue Support
@@ -384,10 +385,11 @@ async function handleSensemakeRequest(request: Request, url: URL, env: Env, cors
 	console.log('OPENROUTER_MODEL', env.OPENROUTER_MODEL);
 	
 	// 解析查詢參數
-	const openRouterApiKey = url.searchParams.get('OPENROUTER_API_KEY') || env.OPENROUTER_API_KEY;
-	const openRouterModel = url.searchParams.get('OPENROUTER_API_KEY') ? (url.searchParams.get('OPENROUTER_MODEL') || env.OPENROUTER_MODEL) : env.OPENROUTER_MODEL;
-	const additionalContext = url.searchParams.get('additionalContext') || url.searchParams.get('a');
-	const outputLang = url.searchParams.get('output_lang') || 'en';
+	const formData = await request.formData();
+	const openRouterApiKey = getFormDataString(formData, 'openRouterApiKey') || url.searchParams.get('OPENROUTER_API_KEY') || env.OPENROUTER_API_KEY;
+	const openRouterModel = getFormDataString(formData, 'openRouterModel') || url.searchParams.get('OPENROUTER_MODEL') || env.OPENROUTER_MODEL;
+	const additionalContext = getFormDataString(formData, 'additionalContext') || url.searchParams.get('additionalContext');
+	const outputLang = getFormDataString(formData, 'outputLang') || url.searchParams.get('output_lang') || 'en';
 
 	// 檢查必需的 API 金鑰
 	if (!openRouterApiKey) {
@@ -433,8 +435,6 @@ async function handleSensemakeRequest(request: Request, url: URL, env: Env, cors
 	console.log('API Key validation passed, proceeding with request processing');
 
 	try {
-		// 解析請求體
-		const formData = await request.formData();
 		const file = formData.get('file') as File;
 
 		if (!file) {

--- a/src/utils/getFormDataString.ts
+++ b/src/utils/getFormDataString.ts
@@ -1,0 +1,4 @@
+export function getFormDataString(formData: FormData, key: string): string {
+  const v = formData.get(key)
+  return typeof v === 'string' ? v : ''
+}


### PR DESCRIPTION
目前 `/api/sensemake` endpoint 參數是由 url query parameters 傳遞，包含了用戶的 open router api key，這可能導致 api key 被抓包工具竊取，或者被保留在雲端服務的 log 中。

這個 PR 先加入 form data 參數的支持，並保持 query parameters 的兼容性。待此變更合併後，再更新[前端改用 form data 傳遞](https://github.com/g0v/sensemaker-frontend/pull/52)，確保服務可持續運行